### PR TITLE
Fix paused torrents being unstyled after searching

### DIFF
--- a/rm-main/src/ui/tabs/torrents/rustmission_torrent.rs
+++ b/rm-main/src/ui/tabs/torrents/rustmission_torrent.rs
@@ -44,7 +44,7 @@ impl RustmissionTorrent {
             if highlighted_indices.contains(&index) {
                 torrent_name_line.push_span(Span::styled(char.to_string(), highlight_style));
             } else {
-                torrent_name_line.push_span(Span::raw(char.to_string()))
+                torrent_name_line.push_span(Span::styled(char.to_string(), self.style))
             }
         }
 

--- a/rm-main/src/ui/tabs/torrents/tasks/filter.rs
+++ b/rm-main/src/ui/tabs/torrents/tasks/filter.rs
@@ -37,10 +37,10 @@ impl Component for FilterBar {
     fn handle_actions(&mut self, action: Action) -> Option<Action> {
         match action {
             Action::Input(input) => {
-                if input.code == KeyCode::Enter {
-                    return Some(Action::Quit);
-                }
-                if input.code == KeyCode::Esc {
+                if matches!(input.code, KeyCode::Enter | KeyCode::Esc) {
+                    if self.input.text().is_empty() {
+                        *self.table_manager.lock().unwrap().filter.lock().unwrap() = None;
+                    }
                     return Some(Action::Quit);
                 }
 


### PR DESCRIPTION
Also set the filter to None if the input is empty which improves performance because we don't have to fuzzy filter each time