### PR TITLE
feat: add upload/download icon in upload/download stat + allow hiding header row

### DIFF
--- a/rm-config/defaults/config.toml
+++ b/rm-config/defaults/config.toml
@@ -12,7 +12,7 @@ accent_color = "LightMagenta"
 beginner_mode = true
 
 # If enabled, hides header row of torrents tab
-hide_headers = false
+headers_hide = false
 
 [connection]
 url = "http://CHANGE_ME:9091/transmission/rpc" # REQUIRED!

--- a/rm-config/defaults/config.toml
+++ b/rm-config/defaults/config.toml
@@ -11,6 +11,9 @@ accent_color = "LightMagenta"
 # a little bit cluttered interface.
 beginner_mode = true
 
+# If enabled, hides header row of torrents tab
+hide_headers = false
+
 [connection]
 url = "http://CHANGE_ME:9091/transmission/rpc" # REQUIRED!
 

--- a/rm-config/src/lib.rs
+++ b/rm-config/src/lib.rs
@@ -26,7 +26,7 @@ pub struct General {
     #[serde(default = "default_beginner_mode")]
     pub beginner_mode: bool,
     #[serde(default)]
-    pub hide_headers: bool,
+    pub headers_hide: bool,
 }
 
 fn default_accent_color() -> Color {

--- a/rm-config/src/lib.rs
+++ b/rm-config/src/lib.rs
@@ -25,6 +25,8 @@ pub struct General {
     pub accent_color: Color,
     #[serde(default = "default_beginner_mode")]
     pub beginner_mode: bool,
+    #[serde(default)]
+    pub hide_headers: bool,
 }
 
 fn default_accent_color() -> Color {

--- a/rm-main/src/ui/tabs/search.rs
+++ b/rm-main/src/ui/tabs/search.rs
@@ -268,7 +268,7 @@ impl Component for SearchTab {
 
         let table = {
             let table = Table::new(items, widths).highlight_style(table_higlight_style);
-            if !self.ctx.config.general.hide_headers {
+            if !self.ctx.config.general.headers_hide {
                 table.header(header)
             } else {
                 table

--- a/rm-main/src/ui/tabs/search.rs
+++ b/rm-main/src/ui/tabs/search.rs
@@ -265,9 +265,15 @@ impl Component for SearchTab {
             .config
             .general
             .accent_color);
-        let table = Table::new(items, widths)
-            .header(header)
-            .highlight_style(table_higlight_style);
+
+        let table = {
+            let table = Table::new(items, widths).highlight_style(table_higlight_style);
+            if !self.ctx.config.general.hide_headers {
+                table.header(header)
+            } else {
+                table
+            }
+        };
 
         f.render_stateful_widget(table, rest, &mut *table_lock.state.borrow_mut());
 

--- a/rm-main/src/ui/tabs/torrents/mod.rs
+++ b/rm-main/src/ui/tabs/torrents/mod.rs
@@ -120,11 +120,17 @@ impl TorrentsTab {
             .general
             .accent_color);
 
-        let table_widget = Table::new(torrent_rows, table_manager_lock.widths)
-            .header(Row::new(
-                table_manager_lock.header().iter().map(|s| s.as_str()),
-            ))
-            .highlight_style(highlight_table_style);
+        let table_widget: Table;
+        table_widget = if self.ctx.config.general.hide_headers {
+            Table::new(torrent_rows, table_manager_lock.widths)
+                .highlight_style(highlight_table_style)
+        } else {
+            Table::new(torrent_rows, table_manager_lock.widths)
+                .highlight_style(highlight_table_style)
+                .header(Row::new(
+                    table_manager_lock.header().iter().map(|s| s.as_str()),
+                ))
+        };
 
         f.render_stateful_widget(
             table_widget,

--- a/rm-main/src/ui/tabs/torrents/mod.rs
+++ b/rm-main/src/ui/tabs/torrents/mod.rs
@@ -120,16 +120,17 @@ impl TorrentsTab {
             .general
             .accent_color);
 
-        let mut table_widget = Table::new(torrent_rows, table_manager_lock.widths)
-            .highlight_style(highlight_table_style);
-
-        if !self.ctx.config.general.hide_headers {
-            table_widget = table_widget
-                .header(Row::new(
+        let table_widget = {
+            let table = Table::new(torrent_rows, table_manager_lock.widths)
+                .highlight_style(highlight_table_style);
+            if !self.ctx.config.general.hide_headers {
+                table.header(Row::new(
                     table_manager_lock.header().iter().map(|s| s.as_str()),
                 ))
-                .clone();
-        }
+            } else {
+                table
+            }
+        };
 
         f.render_stateful_widget(
             table_widget,

--- a/rm-main/src/ui/tabs/torrents/mod.rs
+++ b/rm-main/src/ui/tabs/torrents/mod.rs
@@ -120,17 +120,16 @@ impl TorrentsTab {
             .general
             .accent_color);
 
-        let table_widget: Table;
-        table_widget = if self.ctx.config.general.hide_headers {
-            Table::new(torrent_rows, table_manager_lock.widths)
-                .highlight_style(highlight_table_style)
-        } else {
-            Table::new(torrent_rows, table_manager_lock.widths)
-                .highlight_style(highlight_table_style)
+        let mut table_widget = Table::new(torrent_rows, table_manager_lock.widths)
+            .highlight_style(highlight_table_style);
+
+        if !self.ctx.config.general.hide_headers {
+            table_widget = table_widget
                 .header(Row::new(
                     table_manager_lock.header().iter().map(|s| s.as_str()),
                 ))
-        };
+                .clone();
+        }
 
         f.render_stateful_widget(
             table_widget,

--- a/rm-main/src/ui/tabs/torrents/mod.rs
+++ b/rm-main/src/ui/tabs/torrents/mod.rs
@@ -123,7 +123,7 @@ impl TorrentsTab {
         let table_widget = {
             let table = Table::new(torrent_rows, table_manager_lock.widths)
                 .highlight_style(highlight_table_style);
-            if !self.ctx.config.general.hide_headers {
+            if !self.ctx.config.general.headers_hide {
                 table.header(Row::new(
                     table_manager_lock.header().iter().map(|s| s.as_str()),
                 ))

--- a/rm-main/src/ui/tabs/torrents/rustmission_torrent.rs
+++ b/rm-main/src/ui/tabs/torrents/rustmission_torrent.rs
@@ -1,11 +1,13 @@
 use ratatui::{
     style::{Style, Stylize},
     text::{Line, Span},
-    widgets::Row,
+    widgets::{Cell, Row},
 };
 use transmission_rpc::types::{Id, Torrent, TorrentStatus};
 
-use crate::utils::{bytes_to_human_format, seconds_to_human_format};
+use crate::utils::{
+    bytes_to_human_format, download_speed_format, seconds_to_human_format, upload_speed_format,
+};
 
 #[derive(Clone)]
 pub struct RustmissionTorrent {
@@ -23,12 +25,13 @@ pub struct RustmissionTorrent {
 impl RustmissionTorrent {
     pub fn to_row(&self) -> ratatui::widgets::Row {
         Row::new([
-            self.torrent_name.as_str(),
-            self.size_when_done.as_str(),
-            self.progress.as_str(),
-            self.eta_secs.as_str(),
-            self.download_speed.as_str(),
-            self.upload_speed.as_str(),
+            Cell::new(self.torrent_name.as_str()),
+            Cell::new(""),
+            Cell::new(self.size_when_done.as_str()),
+            Cell::new(self.progress.as_str()),
+            Cell::new(self.eta_secs.as_str()),
+            Cell::new(download_speed_format(&self.download_speed)),
+            Cell::new(upload_speed_format(&self.upload_speed)),
         ])
         .style(self.style)
     }
@@ -49,12 +52,13 @@ impl RustmissionTorrent {
         }
 
         Row::new([
-            torrent_name_line,
-            Line::from(self.size_when_done.as_str()),
-            Line::from(self.progress.as_str()),
-            Line::from(self.eta_secs.as_str()),
-            Line::from(self.download_speed.as_str()),
-            Line::from(self.upload_speed.as_str()),
+            Cell::new(self.torrent_name.as_str()),
+            Cell::new(""),
+            Cell::new(self.size_when_done.as_str()),
+            Cell::new(self.progress.as_str()),
+            Cell::new(self.eta_secs.as_str()),
+            Cell::new(download_speed_format(&self.download_speed)),
+            Cell::new(upload_speed_format(&self.upload_speed)),
         ])
     }
 

--- a/rm-main/src/ui/tabs/torrents/rustmission_torrent.rs
+++ b/rm-main/src/ui/tabs/torrents/rustmission_torrent.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     style::{Style, Stylize},
     text::{Line, Span},
-    widgets::{Cell, Row},
+    widgets::Row,
 };
 use transmission_rpc::types::{Id, Torrent, TorrentStatus};
 
@@ -25,13 +25,13 @@ pub struct RustmissionTorrent {
 impl RustmissionTorrent {
     pub fn to_row(&self) -> ratatui::widgets::Row {
         Row::new([
-            Cell::new(self.torrent_name.as_str()),
-            Cell::new(""),
-            Cell::new(self.size_when_done.as_str()),
-            Cell::new(self.progress.as_str()),
-            Cell::new(self.eta_secs.as_str()),
-            Cell::new(download_speed_format(&self.download_speed)),
-            Cell::new(upload_speed_format(&self.upload_speed)),
+            Line::from(self.torrent_name.as_str()),
+            Line::from(""),
+            Line::from(self.size_when_done.as_str()),
+            Line::from(self.progress.as_str()),
+            Line::from(self.eta_secs.as_str()),
+            Line::from(download_speed_format(&self.download_speed)),
+            Line::from(upload_speed_format(&self.upload_speed)),
         ])
         .style(self.style)
     }
@@ -52,13 +52,13 @@ impl RustmissionTorrent {
         }
 
         Row::new([
-            Cell::new(self.torrent_name.as_str()),
-            Cell::new(""),
-            Cell::new(self.size_when_done.as_str()),
-            Cell::new(self.progress.as_str()),
-            Cell::new(self.eta_secs.as_str()),
-            Cell::new(download_speed_format(&self.download_speed)),
-            Cell::new(upload_speed_format(&self.upload_speed)),
+            Line::from(torrent_name_line),
+            Line::from(""),
+            Line::from(self.size_when_done.as_str()),
+            Line::from(self.progress.as_str()),
+            Line::from(self.eta_secs.as_str()),
+            Line::from(download_speed_format(&self.download_speed)),
+            Line::from(upload_speed_format(&self.upload_speed)),
         ])
     }
 

--- a/rm-main/src/ui/tabs/torrents/table_manager.rs
+++ b/rm-main/src/ui/tabs/torrents/table_manager.rs
@@ -104,11 +104,11 @@ impl TableManager {
         [
             Constraint::Max(70),    // Name
             Constraint::Length(5),  // <padding>
-            Constraint::Length(10), // Size
-            Constraint::Length(10), // Progress
-            Constraint::Length(10), // ETA
-            Constraint::Length(10), // Download
-            Constraint::Length(10), // Upload
+            Constraint::Length(12), // Size
+            Constraint::Length(12), // Progress
+            Constraint::Length(12), // ETA
+            Constraint::Length(12), // Download
+            Constraint::Length(12), // Upload
         ]
     }
 
@@ -124,24 +124,24 @@ impl TableManager {
 
         for row in rows {
             if !row.download_speed.is_empty() {
-                download_width = 9;
+                download_width = 11;
             }
             if !row.upload_speed.is_empty() {
-                upload_width = 9;
+                upload_width = 11;
             }
             if !row.progress.is_empty() {
-                progress_width = 9;
+                progress_width = 11;
             }
 
             if !row.eta_secs.is_empty() {
-                eta_width = 9;
+                eta_width = 11;
             }
         }
 
         [
             Constraint::Max(70),                // Name
             Constraint::Length(5),              // <padding>
-            Constraint::Length(9),              // Size
+            Constraint::Length(11),             // Size
             Constraint::Length(progress_width), // Progress
             Constraint::Length(eta_width),      // ETA
             Constraint::Length(download_width), // Download

--- a/rm-main/src/ui/tabs/torrents/table_manager.rs
+++ b/rm-main/src/ui/tabs/torrents/table_manager.rs
@@ -9,7 +9,7 @@ use super::rustmission_torrent::RustmissionTorrent;
 pub struct TableManager {
     ctx: app::Ctx,
     pub table: GenericTable<RustmissionTorrent>,
-    pub widths: [Constraint; 6],
+    pub widths: [Constraint; 7],
     pub filter: Arc<Mutex<Option<String>>>,
     pub torrents_displaying_no: u16,
     header: Vec<String>,
@@ -26,6 +26,7 @@ impl TableManager {
             torrents_displaying_no: 0,
             header: vec![
                 "Name".to_owned(),
+                "".to_owned(),
                 "Size".to_owned(),
                 "Progress".to_owned(),
                 "ETA".to_owned(),
@@ -99,9 +100,10 @@ impl TableManager {
         rows
     }
 
-    const fn default_widths() -> [Constraint; 6] {
+    const fn default_widths() -> [Constraint; 7] {
         [
             Constraint::Max(70),    // Name
+            Constraint::Length(5),  // <padding>
             Constraint::Length(10), // Size
             Constraint::Length(10), // Progress
             Constraint::Length(10), // ETA
@@ -110,7 +112,7 @@ impl TableManager {
         ]
     }
 
-    fn header_widths(&self, rows: &[RustmissionTorrent]) -> [Constraint; 6] {
+    fn header_widths(&self, rows: &[RustmissionTorrent]) -> [Constraint; 7] {
         if !self.ctx.config.general.auto_hide {
             return Self::default_widths();
         }
@@ -138,6 +140,7 @@ impl TableManager {
 
         [
             Constraint::Max(70),                // Name
+            Constraint::Length(5),              // <padding>
             Constraint::Length(9),              // Size
             Constraint::Length(progress_width), // Progress
             Constraint::Length(eta_width),      // ETA

--- a/rm-main/src/utils.rs
+++ b/rm-main/src/utils.rs
@@ -71,7 +71,7 @@ pub fn download_speed_format(download_speed: &str) -> String {
 
 pub fn upload_speed_format(upload_speed: &str) -> String {
     if upload_speed.len() > 0 {
-        return format!("▼ {}", upload_speed);
+        return format!("▲ {}", upload_speed);
     }
     upload_speed.to_string()
 }

--- a/rm-main/src/utils.rs
+++ b/rm-main/src/utils.rs
@@ -61,3 +61,17 @@ pub fn seconds_to_human_format(seconds: i64) -> String {
     curr_string = format!("{curr_string}{rest}s");
     curr_string
 }
+
+pub fn download_speed_format(download_speed: &str) -> String {
+    if download_speed.len() > 0 {
+        return format!("▼ {}", download_speed);
+    }
+    download_speed.to_string()
+}
+
+pub fn upload_speed_format(upload_speed: &str) -> String {
+    if upload_speed.len() > 0 {
+        return format!("▼ {}", upload_speed);
+    }
+    upload_speed.to_string()
+}


### PR DESCRIPTION
Features added:
- adds upload/download icons to upload/download values
- `hide_headers` config attribute to allow for hiding header row in torrent tab (Name, Completion, Download, Upload, etc)

Purpose is to allow for complete minimalism for pro users (me) that are already familiar with usual torrent statistic values