### PR TITLE
feat: add color to directory header in file popup

### DIFF
--- a/rm-main/src/ui/tabs/torrents/popups/files.rs
+++ b/rm-main/src/ui/tabs/torrents/popups/files.rs
@@ -241,7 +241,10 @@ impl Component for FilesPopup {
                 }
             };
             let block = block
-                .title(Title::from(format!(" {} ", download_dir)).alignment(Alignment::Right))
+                .title(
+                    Title::from(format!(" {} ", download_dir).set_style(highlight_style))
+                        .alignment(Alignment::Right),
+                )
                 .title(
                     Title::from(" [ CLOSE ] ".set_style(close_button_style))
                         .alignment(Alignment::Right)


### PR DESCRIPTION
Adds highlight color to download directory in files popup (i didn't notice the download directory till minutes ago lol)