### PR TITLE
fix: various config issues

### DIFF
--- a/rm-config/defaults/config.toml
+++ b/rm-config/defaults/config.toml
@@ -11,7 +11,7 @@ accent_color = "LightMagenta"
 # a little bit cluttered interface.
 beginner_mode = true
 
-# If enabled, hides header row of torrents tab
+# If enabled, hides table headers
 headers_hide = false
 
 [connection]
@@ -29,10 +29,10 @@ free_space_refresh = 10
 
 [torrents_tab]
 # Available fields:
-# Id, Name, SizeWhenDone, Progress, DownloadRate, UploadRate, DownloadDir,
+# Id, Name, SizeWhenDone, Progress, Eta, DownloadRate, UploadRate, DownloadDir,
 # Padding, UploadRatio, UploadedEver, AddedDate, ActivityDate, PeersConnected
 # SmallStatus
-headers = ["Name", "SizeWhenDone", "Progress", "DownloadRate", "UploadRate"]
+headers = ["Name", "SizeWhenDone", "Progress", "Eta", "DownloadRate", "UploadRate"]
 
 [search_tab]
 # If you uncomment this, providers won't be automatically added in future

--- a/rm-main/src/tui/tabs/torrents/mod.rs
+++ b/rm-main/src/tui/tabs/torrents/mod.rs
@@ -169,7 +169,7 @@ impl TorrentsTab {
         let table_widget = {
             let table = Table::new(self.table_manager.rows(), &self.table_manager.widths)
                 .highlight_style(highlight_table_style);
-            if CONFIG.general.headers_hide {
+            if !CONFIG.general.headers_hide {
                 table.header(Row::new(self.table_manager.headers().iter().cloned()))
             } else {
                 table


### PR DESCRIPTION
Adds ETA column back to the defaults, respects `headers_hide` properly in config.toml under [general]