### PR TITLE
refactor: start moving common things to intuitils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "rm-config"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "rm-shared"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "crossterm",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "rustmission"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 authors = ["Remigiusz Micielski <rmicielski@purelymail.com>"]
 repository = "https://github.com/intuis/rustmission"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ homepage = "https://github.com/intuis/rustmission"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]
-rm-config = { version = "0.4", path = "rm-config" }
-rm-shared = { version = "0.4", path = "rm-shared" }
+rm-config = { version = "0.5", path = "rm-config" }
+rm-shared = { version = "0.5", path = "rm-shared" }
 
 magnetease = "0.3"
 anyhow = "1"

--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,4 +1,9 @@
-# Breaking changes
+# Rustmission 0.5.0
+
+If you don't know what Rustmission is, it's a performant and a featureful TUI for Transmission written in Rust.  
+This release contains many new features, like sorting, multiple selections and more.
+
+## Breaking changes
 In `~/.config/rustmission/keymap.toml` under torrents_tab section replace:
 ```
   { on = "d", action = "DeleteWithoutFiles" },
@@ -11,18 +16,24 @@ with:
 
 This is due to that Rustmission now asks specifically whether to delete a torrent with files or not.
 
-# MULTIPLE SELECTIONS!
+## MULTIPLE SELECTIONS!
 ![image](https://github.com/user-attachments/assets/c6571806-d912-4425-a2c9-56e0ff98ec32)
 
 You can now press `Space` in torrents tab list in order to select multiple torrents. This is useful when you have to delete or move multiple torrents all at once.
 
-# SORTING!
+## SORTING!
 
 ![image](https://github.com/user-attachments/assets/05f89c82-10a7-4588-b2b0-3440378a11d9)
 
-Just press `H` or `L` (that's a big H and L respectively) and see the magic happen
+Just press `H` or `L` (that's a big H and L respectively) and see the magic happen.
+If you have a keymap already, you must update it and bind `MoveToColumnLeft` and `MoveToColumnRight` actions under the `[general]` section in order to make us of this feature like so:
 
-# CATEGORIES WITH DEFAULT DIRECTORIES!
+```
+  { on = "H", action = "MoveToColumnLeft" },
+  { on = "L", action = "MoveToColumnRight" },
+```
+
+## CATEGORIES WITH DEFAULT DIRECTORIES!
 
 Just define one in your `~/.config/rustmission/categories.toml` (which will be automatically generated with some commented-out examples) like this:
 
@@ -45,22 +56,46 @@ If you want to, you can set a category for an already existing torrent using `c`
 ![image](https://github.com/user-attachments/assets/f27fefeb-b242-43c6-890e-e1e2ec80d0f3)
 
 Autocompletion works so you can press TAB/CTRL-F/right and it will auto-complete!  
-`TOOD:` after pressing enter this damn program should ask me whether to move this torrent to the category's default dir or not, but it's not doing that
 
-# YOU CAN NOW SEARCH NYAA.SI FOR MAGNETS!
+After that, you'll be asked to if you want to move the torrent too:  
+
+![image](https://github.com/user-attachments/assets/5748052d-f48d-476b-b05c-a6c559527647)
+
+If you want to make use of this feature and you have your own keymap already, you have to bind `ChangeCategory` action in `keymap.toml` under `[torrents_tab]` like so:
+
+```
+  { on = "c", action = "ChangeCategory" },
+```
+
+## YOU CAN NOW SEARCH NYAA.SI FOR MAGNETS!
 
 ![image](https://github.com/user-attachments/assets/91e9f14d-991f-4c61-a9c3-3ff5887bdac8)
 
 Also improvements to the code were made so that new search providers can be added more easily. Though the `magnetease` crate still needs some polish.
 
-# YOU CAN NOW OPEN TORRENTS DIRECTLY WITH XDG-OPEN
+If you want to be able to access providers popup, you have to bind `ShowProvidersInfo` action under the `search_tab` section like so:
+
+```toml
+[search_tab]
+keybindings = [
+  { on = "p", action = "ShowProvidersInfo" }
+]
+```
+
+## YOU CAN NOW OPEN TORRENTS DIRECTLY WITH XDG-OPEN
 
 ![image](https://github.com/user-attachments/assets/401b2337-d942-4ea0-9b2e-44e363597ce7)
 
 
 In the image shown, in files popup you can now press `o` in order to open selected file in your default application. You can press `o` within just the torrents tab and it will open currently highlighted torrent's directory.
 
-# Icons are now configurable
+If you want to use this feature and you have your own keymap already, you have to bind `XdgOpen` action under the `[general]` section in `keymap.toml` like so:
+
+```
+  { on = "o", action = "XdgOpen" },
+```
+
+## Icons are now configurable
 
 ![image](https://github.com/user-attachments/assets/1cac8aa1-403d-465e-938e-c9df04e81618)
 
@@ -68,33 +103,33 @@ You can now replace these pesky nerd fonts icons if you don't have nerd fonts in
 You can configure them at `.config/rustmission/config.toml` under `[icons]` section.
 Use `rustmission print-default-config` to see the defaults.
 
-# New details popup!
+## New details popup!
 ![image](https://github.com/user-attachments/assets/5a9565dc-5c07-4fca-be72-1e6015d23a97)
 
 You can now press `Enter` while highlighting a torrent in torrents tab to view details about it (together with some useful hotkeys).
 
-# Torrent errors are now being shown!
+## Torrent errors are now being shown!
 
 ![image](https://github.com/user-attachments/assets/4ad34e07-1feb-4406-9890-0d38e377923c)
 
 That was actually very easy to do thanks to Ratatui (the TUI library that Rustmission uses).
 
-# Graphs in statistics!
+## Graphs in statistics!
 
 ![image](https://github.com/user-attachments/assets/c27fc0e6-b9e3-4a26-aa3f-a99cf2e42c54)
 
 Statistics popup isn't now as empty as before.
 
-# Help popup is now much prettier!
+## Help popup is now much prettier!
 
 ![image](https://github.com/user-attachments/assets/7d93bdf7-341f-4e86-9048-8023a05c083b)
 
 And also its text shouldn't take so much vertical space as it did before
 
-# Default config printing
+## Default config printing
 
 You can now type `rustmission print-default-config` or `rustmission print-default-keymap` in order to view the default config/keymap that is up to date.
 
-# Other changes
+## Other changes
 
 There have been also performance improvements related to torrents filtering and action handling so Rustmission takes less CPU cycles for itself than it did before.

--- a/rm-config/src/keymap/actions/general.rs
+++ b/rm-config/src/keymap/actions/general.rs
@@ -36,25 +36,6 @@ pub enum GeneralActionMergable {
 }
 
 impl UserAction for GeneralAction {
-    fn is_mergable_with(&self, other: &GeneralAction) -> bool {
-        let other = *other;
-        match self {
-            GeneralAction::SwitchToTorrents => other == Self::SwitchToSearch,
-            GeneralAction::SwitchToSearch => other == Self::SwitchToTorrents,
-            GeneralAction::Left => other == Self::Right,
-            GeneralAction::Right => other == Self::Left,
-            GeneralAction::Down => other == Self::Up,
-            GeneralAction::Up => other == Self::Down,
-            GeneralAction::ScrollPageDown => other == Self::ScrollPageUp,
-            GeneralAction::ScrollPageUp => other == Self::ScrollPageDown,
-            GeneralAction::GoToBeginning => other == Self::GoToEnd,
-            GeneralAction::GoToEnd => other == Self::GoToBeginning,
-            GeneralAction::MoveToColumnLeft => other == Self::MoveToColumnRight,
-            GeneralAction::MoveToColumnRight => other == Self::MoveToColumnLeft,
-            _ => false,
-        }
-    }
-
     fn desc(&self) -> &'static str {
         match self {
             GeneralAction::ShowHelp => "toggle help",
@@ -80,7 +61,7 @@ impl UserAction for GeneralAction {
         }
     }
 
-    fn merged_desc(&self, other: &GeneralAction) -> Option<&'static str> {
+    fn merge_desc_with(&self, other: &GeneralAction) -> Option<&'static str> {
         match (&self, other) {
             (Self::Left, Self::Right) => Some("switch to tab left / right"),
             (Self::Right, Self::Left) => Some("switch to tab right / left"),

--- a/rm-config/src/keymap/actions/mod.rs
+++ b/rm-config/src/keymap/actions/mod.rs
@@ -6,12 +6,8 @@ pub mod torrents_tab;
 
 pub trait UserAction: Into<Action> {
     fn desc(&self) -> &'static str;
-    fn merged_desc(&self, other: &Self) -> Option<&'static str> {
+    fn merge_desc_with(&self, other: &Self) -> Option<&'static str> {
         let _ = other;
         None
-    }
-    fn is_mergable_with(&self, other: &Self) -> bool {
-        let _ = other;
-        false
     }
 }

--- a/rm-config/src/keymap/mod.rs
+++ b/rm-config/src/keymap/mod.rs
@@ -42,7 +42,7 @@ pub struct KeybindsHolder<T: Into<Action> + UserAction> {
     pub keybindings: Vec<Keybinding<T>>,
 }
 
-impl<T: Into<Action> + Ord + UserAction> KeybindsHolder<T> {
+impl<T: Ord + UserAction> KeybindsHolder<T> {
     const KEYS_DELIMITER: &'static str = ", ";
 
     pub fn get_help_repr(&self) -> Vec<(String, &'static str)> {
@@ -73,7 +73,7 @@ impl<T: Into<Action> + Ord + UserAction> KeybindsHolder<T> {
             }
 
             if let Some((next_action, next_keycodes)) = new_keys.get(idx + 1) {
-                if action.is_mergable_with(next_action) {
+                if let Some(merged_desc) = action.merge_desc_with(next_action) {
                     skip_next_loop = true;
                     let keys = format!(
                         "{} / {}",
@@ -81,11 +81,7 @@ impl<T: Into<Action> + Ord + UserAction> KeybindsHolder<T> {
                         next_keycodes.join(Self::KEYS_DELIMITER)
                     );
 
-                    let desc = action
-                        .merged_desc(next_action)
-                        .expect("keys checked for mergability before");
-
-                    res.push((keys, desc));
+                    res.push((keys, merged_desc));
                     continue;
                 }
             }
@@ -100,7 +96,7 @@ impl<T: Into<Action> + Ord + UserAction> KeybindsHolder<T> {
 }
 
 #[derive(Serialize, Clone)]
-pub struct Keybinding<T: UserAction> {
+pub struct Keybinding<T> {
     pub on: KeyCode,
     #[serde(default)]
     pub modifier: KeyModifier,
@@ -108,7 +104,7 @@ pub struct Keybinding<T: UserAction> {
     pub show_in_help: bool,
 }
 
-impl<T: Into<Action> + UserAction> Keybinding<T> {
+impl<T> Keybinding<T> {
     pub fn keycode_string(&self) -> String {
         let key = match self.on {
             KeyCode::Backspace => "Backspace".into(),
@@ -154,7 +150,7 @@ impl<T: Into<Action> + UserAction> Keybinding<T> {
     }
 }
 
-impl<T: UserAction> Keybinding<T> {
+impl<T> Keybinding<T> {
     fn new(on: KeyCode, action: T, modifier: Option<KeyModifier>, show_in_help: bool) -> Self {
         Self {
             on,
@@ -165,7 +161,7 @@ impl<T: UserAction> Keybinding<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de> + UserAction> Deserialize<'de> for Keybinding<T> {
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Keybinding<T> {
     fn deserialize<D>(deserializer: D) -> std::prelude::v1::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -183,7 +179,7 @@ impl<'de, T: Deserialize<'de> + UserAction> Deserialize<'de> for Keybinding<T> {
             phantom: PhantomData<T>,
         }
 
-        impl<'de, T: Deserialize<'de> + UserAction> Visitor<'de> for KeybindingVisitor<T> {
+        impl<'de, T: Deserialize<'de>> Visitor<'de> for KeybindingVisitor<T> {
             type Value = Keybinding<T>;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -398,7 +394,6 @@ impl KeymapConfig {
         } else {
             Some(keys)
         }
-        
     }
 
     fn populate_hashmap(&mut self) {

--- a/rm-main/Cargo.toml
+++ b/rm-main/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rustmission"
-version = "0.4.3"
-edition = "2021"
 description = "TUI for Transmission daemon"
-repository = "https://github.com/intuis/rustmission"
-homepage = "https://github.com/intuis/rustmission"
-license = "GPL-3.0-or-later"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "rustmission"


### PR DESCRIPTION
Move things like config handling, keybindings, icons to a crate that will be shared among all intuis projects (mainly lemmynator atm).

TODO:
- [x] Cleanup generics
- [ ] Make keycode_string function not dependent on rustmission's config icons
- [ ] Move keybindings related structs into intuitils along with serde deserialization impl for keymap.toml's keybindings